### PR TITLE
Install to /var/local/cyhy instead of /var/cyhy.

### DIFF
--- a/molecule/default/tests/test_default.py
+++ b/molecule/default/tests/test_default.py
@@ -16,7 +16,7 @@ def test_packages(host, pkg):
     assert pkg in host.pip_package.get_packages()
 
 
-@pytest.mark.parametrize("f", ["/var/cyhy/core"])
+@pytest.mark.parametrize("f", ["/var/local/cyhy/core"])
 def test_files(host, f):
     """Test that the expected files and directories are present."""
     assert host.file(f).exists

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -4,16 +4,16 @@
 #
 # Grab the cyhy-core code
 #
-- name: Create the /var/cyhy/core directory
+- name: Create the /var/local/cyhy/core directory
   file:
-    path: /var/cyhy/core
+    path: /var/local/cyhy/core
     state: directory
 
 - name: Download and untar the cyhy-core tarball
   unarchive:
     src: "https://api.github.com/repos/jsf9k/cyhy-core/tarball/develop?\
     access_token={{ github_oauth_token }}"
-    dest: /var/cyhy/core
+    dest: /var/local/cyhy/core
     remote_src: yes
     extra_opts:
       - "--strip-components=1"
@@ -23,4 +23,4 @@
 #
 - name: Install cyhy-core
   pip:
-    name: file:///var/cyhy/core
+    name: file:///var/local/cyhy/core


### PR DESCRIPTION
This avoids conflict with the other cyhy stuff that lives in `/var/cyhy`.