### PR TITLE
Add cisagov/ansible-role-pip as a dependency

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,3 +1,5 @@
+# Already being linted by pretty-format-json
+*.json
 # Already being linted by mdl
 *.md
 # Already being linted by yamllint

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -13,4 +13,6 @@ galaxy_info:
     - cyhy
     - core
 
-dependencies: []
+dependencies:
+  - src: https://github.com/cisagov/ansible-role-pip
+    name: pip

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,11 +1,7 @@
-docker # Needed for molecule to work correctly
-flake8
 # Temporarily use the latest molecule from master.  The latest release
 # of molecule does not play well with ansible 2.8.  We will revert
 # this once a new release comes out.
 #
-# Also install flake8, since it appears to be missing from the
-# dependencies for the bleeding edge molecule.
-# molecule
-git+https://github.com/ansible/molecule.git#egg=molecule
+# molecule[docker]
+git+https://github.com/ansible/molecule.git#egg=molecule[docker]
 pre-commit


### PR DESCRIPTION
pip is used to install jsf9k/cyhy-core.  This passed molecule because molecule explicitly installs pip in `prepare.yml` in order to install boto3.

Also pull in upstream changes from cisagov/skeleton-ansible-role.

Note that the dashboard AMI cannot be built with `packer` until this PR is merged!