### PR TITLE
Update Package Installation Workflow

### DIFF
--- a/molecule/default/tests/test_default.py
+++ b/molecule/default/tests/test_default.py
@@ -18,7 +18,7 @@ def test_packages(host, pkg):
     assert pkg in host.pip_package.get_packages()
 
 
-@pytest.mark.parametrize("f", ["/var/local/cyhy/core", "/usr/local/share/GeoIP"])
+@pytest.mark.parametrize("f", ["/usr/local/share/GeoIP"])
 def test_files(host, f):
     """Test that the expected files and directories are present."""
     assert host.file(f).exists

--- a/molecule/default/tests/test_default.py
+++ b/molecule/default/tests/test_default.py
@@ -18,7 +18,9 @@ def test_packages(host, pkg):
     assert pkg in host.pip_package.get_packages()
 
 
-@pytest.mark.parametrize("f", ["/usr/local/share/GeoIP"])
+@pytest.mark.parametrize(
+    "f", ["/usr/local/share/GeoIP", "/usr/local/share/GeoIP/GeoIP2-City.tar.gz"]
+)
 def test_files(host, f):
     """Test that the expected files and directories are present."""
     assert host.file(f).exists

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,32 +1,9 @@
 ---
 # tasks file for cyhy_core
 
-#
-# Grab the cyhy-core code
-#
-- name: Create the /var/local/cyhy/core directory
-  file:
-    mode: 0755
-    path: /var/local/cyhy/core
-    state: directory
-
-- name: Download and untar the cyhy-core tarball
-  # ansible-lint E208 gives an error if we don't specify the mode,
-  # but we definitely don't want to do that here since it will
-  # override the permissions on the files in the archive.
-  unarchive: # noqa 208
-    src: "https://api.github.com/repos/cisagov/cyhy-core/tarball/develop"
-    dest: /var/local/cyhy/core
-    remote_src: yes
-    extra_opts:
-      - "--strip-components=1"
-
-#
-# Install cyhy-core
-#
-- name: Install cyhy-core
+- name: Install the cyhy-core package
   pip:
-    name: file:///var/local/cyhy/core
+    name: https://api.github.com/repos/cisagov/cyhy-core/tarball/develop
 
 #
 # Download and extract the MaxMind GeoIP database.

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,6 +1,26 @@
 ---
 # tasks file for cyhy_core
 
+- name: Install system versions of the Python packages that cyhy-core needs
+  package:
+    name:
+      # PyCrypto
+      - python-crypto
+      - python-dateutil
+      - python-docopt
+      - python-geoip2
+      - python-maxminddb
+      - python-netaddr
+      - python-pandas
+      - python-progressbar
+      # The version available for Debian Stretch is 3.4.0, and the cyhy-core
+      # package currently has a requirement of < 3. When the cyhy-core package
+      # supports a more recent version of PyMongo, this should be enabled.
+      # - python-pymongo
+      - python-six
+      # PyYAML
+      - python-yaml
+
 - name: Install the cyhy-core package
   pip:
     name: https://api.github.com/repos/cisagov/cyhy-core/tarball/develop


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

This PR updates the installation of the [cisagov/cyhy-core](https://github.com/cisagov/cyhy-core) package to directly install with the `pip` Ansible module. Any requirements that have corresponding packages are installed as system packages as well. Lastly it adds the retrieved GeoIP2 database to the list of items checked in the `molecule` test.

<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and Context ##

This PR is mirroring work done in https://github.com/cisagov/ansible-role-cyhy-runner/pull/16 to update CyHy related Ansible roles. As projects are moved into public repos, we can update their Ansible roles to directly install the package with `pip` instead of retrieving it, extracting it, and then installing it from the local copy. Between that and installing requirements with system packages, it should bring this role in line with how we try to develop now.
<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

Automated tests pass and I built and deployed a database image to test that it worked as expected.
<!-- How did you test your changes? How could someone else test this PR? -->

<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

## ✅ Checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

* [x] This PR has an informative and human-readable title.
* [x] Changes are limited to a single goal - _eschew scope creep!_
* [x] All relevant type-of-change labels have been added.
* [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
* [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
* [x] Tests have been added and/or modified to cover the changes in this PR.
* [x] All new and existing tests pass.
