### PR TITLE
Install the `python-unidecode` package

### DIFF
--- a/molecule/default/tests/test_default.py
+++ b/molecule/default/tests/test_default.py
@@ -24,6 +24,7 @@ testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
         "python-pandas",
         "python-progressbar",
         "python-six",
+        "python-unidecode",
         "python-yaml",
     ],
 )

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -22,6 +22,7 @@
       # version of PyMongo, this should be enabled.
       # - python-pymongo
       - python-six
+      - python-unidecode
       # PyYAML
       - python-yaml
 


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

This pull request updates the role to install the [python-unidecode] package which provides the [Unidecode] Python package.
<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

This package is being added as a dependency for a script in https://github.com/cisagov/cyhy-core/pull/83 so we will need to install it when building images.
<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

The `terraform_validate` hook is failing in the `lint` job because this repository needs the changes in https://github.com/cisagov/skeleton-ansible-role-with-test-user/pull/139. However the `test` job passes and the `lint` job passes otherwise.
<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] Tests have been added and/or modified to cover the changes in this PR.
- [x] All new and existing tests pass.

[cisagov/cyhy-core]: https://github.com/cisagov/cyhy-core
[python-unidecode]: https://packages.debian.org/buster/python-unidecode
[Unidecode]: https://pypi.org/project/Unidecode/